### PR TITLE
remove case-switch statement for extract 

### DIFF
--- a/extract/extract.go
+++ b/extract/extract.go
@@ -68,7 +68,10 @@ func extract(c *context.Context, archiveType string, src string) (error, string)
 	if archiver.SupportedFormats[getArchiverFormat(archiveType)] == nil {
 		err = errors.New(fmt.Sprintf("Error: 'Type' must be one of: %s", archiver.SupportedFormats))
 	}
-
+	if err != nil {
+		return err, ""
+	}
+	err = archiver.SupportedFormats[getArchiverFormat(archiveType)].Open(src, extractedPath)
 	if err != nil {
 		return err, ""
 	}

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -65,7 +65,7 @@ func extract(c *context.Context, archiveType string, src string) (error, string)
 		}
 		return nil, extractedPath
 	}
-	if archiver.SupportedFormats[archiveType] == nil {
+	if archiver.SupportedFormats[getArchiverFormat(archiveType)] == nil {
 		err = errors.New(fmt.Sprintf("Error: 'Type' must be one of: %s", archiver.SupportedFormats))
 	}
 

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -57,24 +57,7 @@ func extract(c *context.Context, archiveType string, src string) (error, string)
 	extractedPath := getExtractedPath(archiveType, src)
 	var err error
 	if c.IsDryRun {
-		switch archiveType {
-		case "zip":
-			err = nil
-		case "tar":
-			err = nil
-		case "tar.gz":
-			err = nil
-		case "tar.bz2":
-			err = nil
-		case "tar.xz":
-			err = nil
-		case "tar.lz4":
-			err = nil
-		case "tar.sz":
-			err = nil
-		case "rar":
-			err = nil
-		default:
+		if archiver.SupportedFormats[getArchiverFormat(archiveType)] == nil {
 			err = errors.New(fmt.Sprintf("Error: 'Type' must be one of: %s", archiver.SupportedFormats))
 		}
 		if err != nil {
@@ -82,24 +65,7 @@ func extract(c *context.Context, archiveType string, src string) (error, string)
 		}
 		return nil, extractedPath
 	}
-	switch archiveType {
-	case "zip":
-		err = archiver.Zip.Open(src, extractedPath)
-	case "tar":
-		err = archiver.Tar.Open(src, extractedPath)
-	case "tar.gz":
-		err = archiver.TarGz.Open(src, extractedPath)
-	case "tar.bz2":
-		err = archiver.TarBz2.Open(src, extractedPath)
-	case "tar.xz":
-		err = archiver.TarXZ.Open(src, extractedPath)
-	case "tar.lz4":
-		err = archiver.TarLz4.Open(src, extractedPath)
-	case "tar.sz":
-		err = archiver.TarSz.Open(src, extractedPath)
-	case "rar":
-		err = archiver.Rar.Open(src, extractedPath)
-	default:
+	if archiver.SupportedFormats[archiveType] == nil {
 		err = errors.New(fmt.Sprintf("Error: 'Type' must be one of: %s", archiver.SupportedFormats))
 	}
 
@@ -133,6 +99,24 @@ func copyToTarget(src string, target string) error {
 	}
 
 	return nil
+}
+
+func getArchiverFormat(archiveType string) string {
+	if archiveType == "tar" {
+		return "Tar"
+	}
+	if archiveType == "zip" {
+		return "Zip"
+	}
+	if archiveType == "rar" {
+		return "Rar"
+	}
+	if archiveType == "tar.xz" {
+		return "TarXZ"
+	}
+	archiverFormat := strings.Replace(archiveType, "tar.", "", 1)
+	archiverFormat = strings.Title(archiverFormat)
+	return "Tar" + archiverFormat
 }
 
 func getExtractedPath(archiveType string, src string) string {

--- a/extract/extract_test.go
+++ b/extract/extract_test.go
@@ -6,7 +6,49 @@ import (
 	"testing"
 )
 
-func TestExtractDryRun(t *testing.T) {
+func TestExtractDryRunTar(t *testing.T) {
+	ctx := context.New(true)
+	binary := config.Binary{
+		Name:   "test",
+		Src:    "https://test.com/test.tar",
+		Format: "tar",
+		Mode:   0700,
+	}
+	_, err := Run(&ctx, binary, "/tmp/binary.tar")
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+}
+
+func TestExtractDryRunRar(t *testing.T) {
+	ctx := context.New(true)
+	binary := config.Binary{
+		Name:   "test",
+		Src:    "https://test.com/test.rar",
+		Format: "rar",
+		Mode:   0700,
+	}
+	_, err := Run(&ctx, binary, "/tmp/binary.rar")
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+}
+
+func TestExtractDryRunZip(t *testing.T) {
+	ctx := context.New(true)
+	binary := config.Binary{
+		Name:   "test",
+		Src:    "https://test.com/test.zip",
+		Format: "zip",
+		Mode:   0700,
+	}
+	_, err := Run(&ctx, binary, "/tmp/binary.zip")
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+}
+
+func TestExtractDryRunTarGz(t *testing.T) {
 	ctx := context.New(true)
 	binary := config.Binary{
 		Name:   "test",
@@ -15,6 +57,62 @@ func TestExtractDryRun(t *testing.T) {
 		Mode:   0700,
 	}
 	_, err := Run(&ctx, binary, "/tmp/binary.tar.gz")
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+}
+
+func TestExtractDryRunTarBz2(t *testing.T) {
+	ctx := context.New(true)
+	binary := config.Binary{
+		Name:   "test",
+		Src:    "https://test.com/test.tar.bz2",
+		Format: "tar.bz2",
+		Mode:   0700,
+	}
+	_, err := Run(&ctx, binary, "/tmp/binary.tar.bz2")
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+}
+
+func TestExtractDryRunTarXz(t *testing.T) {
+	ctx := context.New(true)
+	binary := config.Binary{
+		Name:   "test",
+		Src:    "https://test.com/test.tar.xz",
+		Format: "tar.xz",
+		Mode:   0700,
+	}
+	_, err := Run(&ctx, binary, "/tmp/binary.tar.xz")
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+}
+
+func TestExtractDryRunTarLz4(t *testing.T) {
+	ctx := context.New(true)
+	binary := config.Binary{
+		Name:   "test",
+		Src:    "https://test.com/test.tar.lz4",
+		Format: "tar.lz4",
+		Mode:   0700,
+	}
+	_, err := Run(&ctx, binary, "/tmp/binary.tar.lz4")
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+}
+
+func TestExtractDryRunTarSz(t *testing.T) {
+	ctx := context.New(true)
+	binary := config.Binary{
+		Name:   "test",
+		Src:    "https://test.com/test.tar.sz",
+		Format: "tar.sz",
+		Mode:   0700,
+	}
+	_, err := Run(&ctx, binary, "/tmp/binary.tar.sz")
 	if err != nil {
 		t.Fatalf("Expected no error, got %s", err)
 	}


### PR DESCRIPTION
The function getArchiveFormat() converts all file extensions to supported [mholt/archiver](https://github.com/mholt/archiver) formats.

The tests include all supported archive formats.

Also, this resolves #5 